### PR TITLE
feat(docker,pterodactyl): add `arm64` support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,7 @@ jobs:
         id: docker_build
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           target: 'runner'
           cache-from: type=registry,ref=ghcr.io/dynamicabot/dynamica-v2:latest
           build-args: |
@@ -124,6 +125,7 @@ jobs:
         uses: docker/build-push-action@v5
         id: docker_build_pterodactyl
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           target: 'pterodactyl'
           build-args: |
@@ -136,6 +138,7 @@ jobs:
         uses: docker/build-push-action@v5
         id: docker_build_dist
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           target: 'dist'
           push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ARG VERSION
 ENV VERSION=$VERSION
 COPY --from=prod-deps /app/node_modules /app/node_modules
 COPY --from=build /app/dist /app/dist
+RUN apk update && apk add bash
 RUN ls -la /app/dist
 CMD [ "pnpm", "start" ]
 

--- a/dynamica-egg.json
+++ b/dynamica-egg.json
@@ -21,7 +21,7 @@
   "scripts": {
     "installation": {
       "script": null,
-      "container": "alpine:3.4",
+      "container": "alpine:3.19",
       "entrypoint": "ash"
     }
   },

--- a/dynamica-egg.json
+++ b/dynamica-egg.json
@@ -30,7 +30,7 @@
       "name": "Database Path",
       "description": "The path in which to create the sqlite database.",
       "env_variable": "DATABASE_URL",
-      "default_value": "file:/home/container/dynamica-v2/db.sqlite",
+      "default_value": "file:/home/container/db.sqlite",
       "user_viewable": true,
       "user_editable": false,
       "rules": "required|string"


### PR DESCRIPTION
Should close #353

Please check if your build system works. I haven't set up the secrets as I don't really have the time to figure out how the rest of the workflow works. But it should be fine as I only added `platforms: linux/amd64,linux/arm64` to docker build action and bumped `apline:3.4` to `alpine:3.19` because `3.4` doesn't have an `arm64` build.